### PR TITLE
Remove unnecessary cp command

### DIFF
--- a/app_v2/install.sh
+++ b/app_v2/install.sh
@@ -5,7 +5,6 @@ mkdir -p /opt/cloudsqlproxy/
 
 pushd $(dirname $0)
 cp -R ./* /opt/dengonban/v2/
-cp ../cloud_sql_proxy /opt/cloudsqlproxy/
 cp ./dengonban.service /etc/systemd/system/
 cp ./cloudsqlproxy.service /etc/systemd/system/
 popd

--- a/app_v3/install.sh
+++ b/app_v3/install.sh
@@ -5,7 +5,6 @@ mkdir -p /opt/cloudsqlproxy/
 
 pushd $(dirname $0)
 cp -R ./* /opt/dengonban/v3/
-cp ../cloud_sql_proxy /opt/cloudsqlproxy/
 cp ./dengonban.service /etc/systemd/system/
 cp ./cloudsqlproxy.service /etc/systemd/system/
 popd


### PR DESCRIPTION
問題はありませんが、app_v2/install.sh と app_v3/install.sh で以下のエラーメッセージが出るので、修正してみました。

```
$ sudo app_v2/install.sh
(snip)
+ cp ../cloud_sql_proxy /opt/cloudsqlproxy/
cp: cannot stat ‘../cloud_sql_proxy’: No such file or directory
(snip)
```

P84 で cloud_sql_proxy は /opt/cloudsqlproxy/ に mv 済みですので、このタイミングでの cp はエラーメッセージが出てしまいます。
